### PR TITLE
fix missing parentheses

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,7 +10,7 @@
 				"<!(node -e \"require('nan')\")"
 			],
 			"libraries": [
-				'-lXInput'
+				'-lXInput9_1_0'
 			]
 		}
 	]

--- a/index.js
+++ b/index.js
@@ -81,13 +81,13 @@ class XInputDevice extends EventEmitter {
 
 			if(state) {
 				this._holdTimes[key] = new Date().getTime();
-				this._holdTimers[key] = setTimeout(() => {
+				this._holdTimers[key] = setTimeout((() => {
 					let now = new Date().getTime();
 					let timePressed = this._holdTimes[key] || now;
 					let elapsed = now - timePressed;
 
 					this.emit("button-long", key, elapsed);
-				}.bind(this), this.options.holdtime);
+				}).bind(this), this.options.holdtime);
 			} else {
 				let now = new Date().getTime();
 				let timePressed = this._holdTimes[key] || now;


### PR DESCRIPTION
index.js would not execute in node 7.4.0 due to missing parentheses around es6-style function declaration before calling bind().